### PR TITLE
GetServerTime for udi timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.1.6] - 2023-04-08
+
+### Fixed
+- The last_seen and last_alerted timestamps were incorrectly using the time the computer has been active. They now use the epoch time, which should fix an issue where alerts were not generated when they should have been.
+- Fixed and issue with name-only matched alert generations that was causing lua errors where a GUID was not present in the case data.
+
 ## [0.1.5] - 2023-01-25
 
 ### Fixed

--- a/core.lua
+++ b/core.lua
@@ -580,21 +580,22 @@ function SB:is_off_alert_lockout()
 	local udi = self:get_UDI()
 	local q = self.query
 	local index = q.guid
+	local timeNow=GetServerTime()
 	if not q.guid_match then
 		index = q.full_name
 	end
 	if not udi[index].last_alerted then
-		udi[index].last_alerted = GetServerTime()
+		udi[index].last_alerted = timeNow
 		return true
 	end
 
 	local delta = self:get_opts_db().alert_lockout_seconds
-	if GetServerTime() < delta + udi[index].last_alerted then
-		local time_until = delta + udi[index].last_alerted - GetServerTime()
+	if timeNow < delta + udi[index].last_alerted then
+		local time_until = delta + udi[index].last_alerted - timeNow
 		-- self:Print(string.format("locked out for another %f seconds", time_until))
 		return false
 	end
-	udi[index].last_alerted = GetServerTime()
+	udi[index].last_alerted = timeNow
 	return true
 end
 

--- a/core.lua
+++ b/core.lua
@@ -16,7 +16,7 @@ local CreateTextureMarkup = CreateTextureMarkup
 local GetInviteConfirmationInfo = GetInviteConfirmationInfo
 local GetNextPendingInviteConfirmation = GetNextPendingInviteConfirmation
 local GetUnitName = GetUnitName
-local GetTime = GetTime
+local GetServerTime = GetServerTime
 local GetPlayerInfoByGUID = GetPlayerInfoByGUID
 local GetRealmName = GetRealmName
 local IsInInstance = IsInInstance
@@ -584,17 +584,17 @@ function SB:is_off_alert_lockout()
 		index = q.full_name
 	end
 	if not udi[index].last_alerted then
-		udi[index].last_alerted = GetTime()
+		udi[index].last_alerted = GetServerTime()
 		return true
 	end
 
 	local delta = self:get_opts_db().alert_lockout_seconds
-	if GetTime() < delta + udi[index].last_alerted then
-		local time_until = delta + udi[index].last_alerted - GetTime()
+	if GetServerTime() < delta + udi[index].last_alerted then
+		local time_until = delta + udi[index].last_alerted - GetServerTime()
 		-- self:Print(string.format("locked out for another %f seconds", time_until))
 		return false
 	end
-	udi[index].last_alerted = GetTime()
+	udi[index].last_alerted = GetServerTime()
 	return true
 end
 

--- a/core.lua
+++ b/core.lua
@@ -580,7 +580,7 @@ function SB:is_off_alert_lockout()
 	local udi = self:get_UDI()
 	local q = self.query
 	local index = q.guid
-	local timeNow=GetServerTime()
+	local timeNow = GetServerTime()
 	if not q.guid_match then
 		index = q.full_name
 	end
@@ -707,7 +707,7 @@ function SB:update_UDI()
 	local p = udi[index]
 
 	-- Always update last seen
-	p.last_seen = GetTime()
+	p.last_seen = GetServerTime()
 
 	-- At this point can also check the provider names against the actual name of
 	-- any GUID-matched player in-game.
@@ -742,6 +742,9 @@ function SB:construct_printout_headline()
 	local q = self.query
 	local udi = self:get_UDI()
 	local u = udi[q.guid]
+	if not u then
+		u = udi[q.full_name]
+	end
 	local name = self:colorise_name(u.short_name, u.english_class)
 	if u == nil then
 		u = udi[q.full_name]

--- a/test_list.lua
+++ b/test_list.lua
@@ -41,7 +41,7 @@ local case_data_1 = {
                 name = "Swedger",
             },
             [1] = {
-                name = "Accomplice",
+                name = "Kasuka",
                 class = "DRUID",
             }
         },

--- a/test_list.lua
+++ b/test_list.lua
@@ -48,6 +48,12 @@ local case_data_1 = {
         category = "trade",
         url = "https://wowpedia.fandom.com/wiki/Void",
     },
+    [5] = {
+        guid = "Player-4904-007D2BDC",
+        category = "gdkp",
+        description = "Some test description for incident with the player.",
+        url = "https://wowpedia.fandom.com/wiki/Outland",
+    },
 }
 
 local test_bl_1 = {


### PR DESCRIPTION
To solve Scambuster not trigging if you have rebooted your computer recently and had it active for long time previously here is a change in function usage to use GetServerTime() which should not change based on when you rebooted.
Since server time is unix time these values will be way larger so alerts should still happen with these changes.


Another way to solve this issue could be to clear udi table on each login.
